### PR TITLE
Added support for fetching attributes as byte[]s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ Several additional properties can be configured, but sensible defaults should pr
         domainController: my-fav-dc.my.company.example.com # Default: <domain>
         sslEnabled: true  # Default: true
         usernameFilterTemplate: (&((&(objectCategory=Person)(objectClass=User)))(sAMAccountName=%s)) # Default: <As shown> %s replaced with the sAMAccountName
-        attributeNames: # Default: <As Shown>. first two are required.
+        attributeNames: # Default: <As Shown>. first two are required. Will be fetched as String.
             - sAMAccountName
             - memberOf
             - mail
+        binaryAttributeNames: # Default: empty. Will be fetched as byte[]. Need for the ones below.
+            - objectGUID
+            - objectSid
         connectionTimeout: 1000 # Default: as shown in millseconds
         readTimeout: 1000 # Default: as shown in millseconds
         requiredGroups: # Default: <empty>

--- a/module/src/main/java/com/commercehub/dropwizard/authentication/AdConfiguration.java
+++ b/module/src/main/java/com/commercehub/dropwizard/authentication/AdConfiguration.java
@@ -30,6 +30,14 @@ public class AdConfiguration {
     private String usernameFilterTemplate = "(&((&(objectCategory=Person)(objectClass=User)))(sAMAccountName=%s))";
 
     private String[] attributeNames = new String[]{"sAMAccountName", "mail", "memberOf"};
+
+    /**
+     * LDAP/AD keys whose values are expected to be binary.
+     *
+     * All these will be returned as byte[] instead of Strings. Typical examples would be "objectGUID" or "objectSid".
+     */
+    private String[] binaryAttributeNames;
+
     private boolean sslEnabled = true;
 
     @NotNull
@@ -95,6 +103,14 @@ public class AdConfiguration {
 
     public String[] getAttributeNames() {
         return attributeNames;
+    }
+
+    public String[] getBinaryAttributeNames() {
+        return binaryAttributeNames;
+    }
+
+    public void setBinaryAttributeNames(String[] binaryAttributeNames) {
+        this.binaryAttributeNames = binaryAttributeNames;
     }
 
     public String getLdapUrl() {


### PR DESCRIPTION
This is needed if the data is not in string format. Examples are the `objectGUID` and `objectSid` attributes which are required to get a long-term ID - `sAMAccountName` can be re-used over time.