### PR TITLE
Added null checking to AdUtilities

### DIFF
--- a/module/src/main/java/com/commercehub/dropwizard/authentication/AdUtilities.java
+++ b/module/src/main/java/com/commercehub/dropwizard/authentication/AdUtilities.java
@@ -1,6 +1,7 @@
 package com.commercehub.dropwizard.authentication;
 
 import com.commercehub.dropwizard.authentication.support.CaseInsensitiveHashMap;
+import org.apache.commons.lang.StringUtils;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -57,8 +58,10 @@ public class AdUtilities {
         return result;
     }
 
-    public static String extractDNParticle(String dn, String particle){
-
+    public static String extractDNParticle(String dn, String particle) {
+        if (StringUtils.isBlank(dn) || StringUtils.isBlank(particle)) {
+            return null;
+        }
         for(String part: dn.split(",")){
             String upperPart = part.toUpperCase();
             String upperParticle = particle.toUpperCase();
@@ -72,10 +75,12 @@ public class AdUtilities {
 
     public static Set<String> extractDNParticles(Collection<String> dnStrings, String particle){
         Set<String> result = new HashSet<>();
-        for(String dn: dnStrings){
-            String value = extractDNParticle(dn, particle);
-            if(null!=value){
-                result.add(value);
+        if (dnStrings != null) {
+            for (String dn : dnStrings) {
+                String value = extractDNParticle(dn, particle);
+                if (null != value) {
+                    result.add(value);
+                }
             }
         }
         return result;

--- a/module/src/test/groovy/com/commercehub/dropwizard/authentication/AdUtilitiesTest.groovy
+++ b/module/src/test/groovy/com/commercehub/dropwizard/authentication/AdUtilitiesTest.groovy
@@ -15,6 +15,14 @@ public class AdUtilitiesTest {
         assertEquals("could not extract dc", 'commercehub', AdUtilities.extractDNParticle(dn, "dc"));
     }
 
+    @Test
+    public void dnParticleExtraction_null() {
+        def dn = "cn=one,ou= two ,dc=commercehub,dc=com"
+        assertNull(AdUtilities.extractDNParticle(null, null));
+        assertNull(AdUtilities.extractDNParticle(null, "cn"));
+        assertNull(AdUtilities.extractDNParticle(dn, null));
+        assertNull(AdUtilities.extractDNParticle(dn, "xx"));
+    }
 
     @Test
     public void dnCaseInsensitiveParticleExtraction()  {
@@ -29,6 +37,15 @@ public class AdUtilitiesTest {
         //This list has purposefully messy examples
         def dns = ["cn=one,dc=commercehub,dc=com","fo=bar,cn=two,dc=commercehub,dc=com","jo=king,cn=three ,o=has-space,dc=commercehub,dc=com",]
         assertEquals("Could not extract cn's from list", ["one", "two", "three"] as Set, AdUtilities.extractDNParticles(dns, "cn"));
+    }
+
+    @Test
+    public void dnParticlesExtraction_Null() {
+        def dns = ["cn=one,dc=commercehub,dc=com","fo=bar,cn=two,dc=commercehub,dc=com","jo=king,cn=three ,o=has-space,dc=commercehub,dc=com",]
+        assertEquals(0, AdUtilities.extractDNParticles(null, null).size());
+        assertEquals(0, AdUtilities.extractDNParticles(null, "cn").size());
+        assertEquals(0, AdUtilities.extractDNParticles(dns, null).size());
+        assertEquals(0, AdUtilities.extractDNParticles(dns, "xx").size());
     }
 
     @Test


### PR DESCRIPTION
AdUtilities lacked resiliency when it came to null inputs, which could occur if an AD user lacked any groups or could not be fully authenticated for whatever reason.